### PR TITLE
stabilize and fix crash bug

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ set(COLONIO_FILES
   core/pubsub_2d.cpp
   core/pubsub_2d_api.pb.cc
   core/pubsub_2d_impl.cpp
+  core/random.cpp
   core/routing.cpp
   core/routing_protocol.pb.cc
   core/routing_1d.cpp

--- a/src/core/api_gate_mt.cpp
+++ b/src/core/api_gate_mt.cpp
@@ -261,12 +261,15 @@ void APIGateMultiThread::loop_controller() {
               .map("message", ex.message);
           reply_failure(call->id(), ex.code, ex.message);
 
-        } catch (const std::exception& ex) {
+        }
+#ifndef NDEBUG
+        catch (const std::exception& ex) {
           logE(controller, "exception").map("message", std::string(ex.what()));
           reply_failure(call->id(), ErrorCode::UNDEFINED, ex.what());
           // TODO stop
           return;
         }
+#endif
       }
     }
 
@@ -286,11 +289,14 @@ void APIGateMultiThread::loop_controller() {
     } catch (const InternalException& ex) {
       logE(controller, "internal exception").map("file", ex.file).map_int("line", ex.line).map("message", ex.message);
 
-    } catch (const std::exception& ex) {
+    }
+#ifndef NDEBUG
+    catch (const std::exception& ex) {
       logE(controller, "exception").map("message", std::string(ex.what()));
       // TODO stop
       return;
     }
+#endif
   }
 }
 

--- a/src/core/api_gate_mt.cpp
+++ b/src/core/api_gate_mt.cpp
@@ -18,10 +18,8 @@
 
 #include <cassert>
 #include <chrono>
-#include <random>
 
 #include "logger.hpp"
-#include "utils.hpp"
 
 namespace colonio {
 
@@ -53,7 +51,7 @@ void APIGateMultiThread::call_async(
   {
     std::lock_guard<std::mutex> lock(mtx_reply);
     do {
-      id = Utils::get_rnd_32();
+      id = random.generate_u32();
     } while (id != 0 && map_reply.find(id) != map_reply.end());
     map_reply.insert(std::make_pair(id, Reply(on_reply)));
   }
@@ -75,7 +73,7 @@ std::unique_ptr<api::Reply> APIGateMultiThread::call_sync(APIChannel::Type chann
   {
     std::lock_guard<std::mutex> lock(mtx_reply);
     do {
-      id = Utils::get_rnd_32();
+      id = random.generate_u32();
     } while (id != 0 && map_reply.find(id) != map_reply.end());
     map_reply.insert(std::make_pair(id, Reply()));
   }

--- a/src/core/api_gate_mt.cpp
+++ b/src/core/api_gate_mt.cpp
@@ -262,7 +262,7 @@ void APIGateMultiThread::loop_controller() {
           reply_failure(call->id(), ex.code, ex.message);
 
         }
-#ifndef NDEBUG
+#ifdef NDEBUG
         catch (const std::exception& ex) {
           logE(controller, "exception").map("message", std::string(ex.what()));
           reply_failure(call->id(), ErrorCode::UNDEFINED, ex.what());
@@ -290,7 +290,7 @@ void APIGateMultiThread::loop_controller() {
       logE(controller, "internal exception").map("file", ex.file).map_int("line", ex.line).map("message", ex.message);
 
     }
-#ifndef NDEBUG
+#ifdef NDEBUG
     catch (const std::exception& ex) {
       logE(controller, "exception").map("message", std::string(ex.what()));
       // TODO stop

--- a/src/core/api_gate_mt.hpp
+++ b/src/core/api_gate_mt.hpp
@@ -22,6 +22,7 @@
 
 #include "api_gate.hpp"
 #include "controller.hpp"
+#include "random.hpp"
 
 namespace colonio {
 class APIGateMultiThread : public APIGateBase, public ControllerDelegate {
@@ -60,6 +61,7 @@ class APIGateMultiThread : public APIGateBase, public ControllerDelegate {
   std::mutex mtx_end;
 
   Controller controller;
+  Random random;
 
   std::deque<std::unique_ptr<api::Call>> que_call;
   std::map<uint32_t, Reply> map_reply;

--- a/src/core/api_gate_wasm.cpp
+++ b/src/core/api_gate_wasm.cpp
@@ -58,7 +58,7 @@ void APIGateWASM::call_async(
     APIChannel::Type channel, const api::Call& c, std::function<void(const api::Reply&)> on_reply) {
   uint32_t id;
   do {
-    id = Utils::get_rnd_32();
+    id = random.generate_u32();
   } while (id != 0 && map_reply.find(id) != map_reply.end());
   map_reply.insert(std::make_pair(id, on_reply));
 
@@ -183,7 +183,7 @@ void APIGateWASM::call_reply(std::unique_ptr<api::Reply> reply, std::function<vo
 void APIGateWASM::push_call(std::function<void()> func) {
   uint32_t id;
   do {
-    id = Utils::get_rnd_32();
+    id = random.generate_u32();
   } while (id != 0 && map_call.find(id) != map_call.end());
   map_call.insert(std::make_pair(id, func));
   api_gate_require_call_after(reinterpret_cast<COLONIO_PTR_T>(this), static_cast<COLONIO_CALL_ID_T>(id));

--- a/src/core/api_gate_wasm.hpp
+++ b/src/core/api_gate_wasm.hpp
@@ -38,6 +38,7 @@ class APIGateWASM : public APIGateBase, public ControllerDelegate {
 
  private:
   Controller controller;
+  Random random;
 
   std::map<uint32_t, std::function<void(const api::Reply&)>> map_reply;
   std::map<APIChannel::Type, std::function<void(const api::Event&)>> map_event;

--- a/src/core/colonio_impl.cpp
+++ b/src/core/colonio_impl.cpp
@@ -166,9 +166,9 @@ void ColonioImpl::seed_accessor_on_recv_config(SeedAccessor& sa, const picojson:
     if (Utils::check_json_optional(config, "coordSystem2D", &cs2d_config)) {
       const std::string& type = Utils::get_json<std::string>(cs2d_config, "type");
       if (type == "sphere") {
-        coord_system = std::make_unique<CoordSystemSphere>(cs2d_config);
+        coord_system = std::make_unique<CoordSystemSphere>(context.random, cs2d_config);
       } else if (type == "plane") {
-        coord_system = std::make_unique<CoordSystemPlane>(cs2d_config);
+        coord_system = std::make_unique<CoordSystemPlane>(context.random, cs2d_config);
       }
     }
 

--- a/src/core/context.cpp
+++ b/src/core/context.cpp
@@ -22,8 +22,8 @@
 
 namespace colonio {
 
-Context::Context(Logger& logger_, Scheduler& scheduler_) :
-    logger(logger_), scheduler(scheduler_), local_nid(NodeID::make_random()) {
+Context::Context(Logger& logger_, Random& random_, Scheduler& scheduler_) :
+    logger(logger_), random(random_), scheduler(scheduler_), local_nid(NodeID::make_random(random)) {
 }
 
 Context::~Context() {

--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -21,7 +21,7 @@ ControllerDelegate::~ControllerDelegate() {
 }
 
 Controller::Controller(ControllerDelegate& delegate_) :
-    delegate(delegate_), logger(*this), scheduler(*this, logger), context(logger, scheduler) {
+    delegate(delegate_), logger(*this), scheduler(*this, logger), context(logger, random, scheduler) {
   colonio_impl = std::make_shared<ColonioImpl>(context, *this, bundler);
   bundler.registrate(colonio_impl);
 }

--- a/src/core/controller.hpp
+++ b/src/core/controller.hpp
@@ -19,6 +19,7 @@
 #include "colonio_impl.hpp"
 #include "context.hpp"
 #include "logger.hpp"
+#include "random.hpp"
 #include "scheduler.hpp"
 
 namespace colonio {
@@ -44,6 +45,7 @@ class Controller : public LoggerDelegate, public SchedulerDelegate, public APIDe
 
  private:
   ControllerDelegate& delegate;
+  Random random;
   Scheduler scheduler;
   Context context;
   APIBundler bundler;

--- a/src/core/coord_system_plane.cpp
+++ b/src/core/coord_system_plane.cpp
@@ -19,15 +19,16 @@
 #include <cmath>
 #include <limits>
 
+#include "random.hpp"
 #include "utils.hpp"
 
 namespace colonio {
-CoordSystemPlane::CoordSystemPlane(const picojson::object& config) :
+CoordSystemPlane::CoordSystemPlane(Random& random, const picojson::object& config) :
     CoordSystem(
         Utils::get_json<double>(config, "xMin"), Utils::get_json<double>(config, "yMin"),
         Utils::get_json<double>(config, "xMax"), Utils::get_json<double>(config, "yMax"),
         (Utils::get_json<double>(config, "xMax") - Utils::get_json<double>(config, "xMin")) / UINT32_MAX),
-    local_position(Coordinate(Utils::get_rnd_double(MIN_X, MAX_X), Utils::get_rnd_double(MIN_Y, MAX_Y))) {
+    local_position(Coordinate(random.generate_double(MIN_X, MAX_X), random.generate_double(MIN_Y, MAX_Y))) {
 }
 
 double CoordSystemPlane::get_distance(const Coordinate& p1, const Coordinate& p2) const {

--- a/src/core/coord_system_plane.hpp
+++ b/src/core/coord_system_plane.hpp
@@ -20,9 +20,11 @@
 #include "coord_system.hpp"
 
 namespace colonio {
+class Random;
+
 class CoordSystemPlane : public CoordSystem {
  public:
-  CoordSystemPlane(const picojson::object& config);
+  CoordSystemPlane(Random& random, const picojson::object& config);
 
   // CoordSystem
   double get_distance(const Coordinate& p1, const Coordinate& p2) const override;

--- a/src/core/coord_system_sphere.cpp
+++ b/src/core/coord_system_sphere.cpp
@@ -19,15 +19,16 @@
 #include <cmath>
 #include <limits>
 
+#include "random.hpp"
 #include "utils.hpp"
 
 namespace colonio {
-CoordSystemSphere::CoordSystemSphere(const picojson::object& config) :
+CoordSystemSphere::CoordSystemSphere(Random& random, const picojson::object& config) :
     CoordSystem(M_PI * -1.0, M_PI * -0.5, M_PI * 1.0, M_PI * 0.5, 0.0001 / 60.0),
     conf_radius(0),
     local_position(
-        (2.0 * M_PI * static_cast<double>(Utils::get_rnd_32()) / static_cast<double>(UINT32_MAX)) - M_PI * 1.0,
-        (1.0 * M_PI * static_cast<double>(Utils::get_rnd_32()) / static_cast<double>(UINT32_MAX)) - M_PI * 0.5) {
+        (2.0 * M_PI * static_cast<double>(random.generate_u32()) / static_cast<double>(UINT32_MAX)) - M_PI * 1.0,
+        (1.0 * M_PI * static_cast<double>(random.generate_u32()) / static_cast<double>(UINT32_MAX)) - M_PI * 0.5) {
   conf_radius = Utils::get_json<double>(config, "radius");
 }
 

--- a/src/core/coord_system_sphere.hpp
+++ b/src/core/coord_system_sphere.hpp
@@ -20,9 +20,11 @@
 #include "coord_system.hpp"
 
 namespace colonio {
+class Random;
+
 class CoordSystemSphere : public CoordSystem {
  public:
-  CoordSystemSphere(const picojson::object& config);
+  CoordSystemSphere(Random& random, const picojson::object& config);
 
   // CoordSystem
   double get_distance(const Coordinate& p1, const Coordinate& p2) const override;

--- a/src/core/module_base.cpp
+++ b/src/core/module_base.cpp
@@ -145,12 +145,12 @@ void ModuleBase::relay_packet(const NodeID& dst_nid, std::unique_ptr<const Packe
  */
 void ModuleBase::send_packet(
     std::unique_ptr<Command> command, const NodeID& dst_nid, std::shared_ptr<const std::string> content) {
-  uint32_t packet_id = Utils::get_rnd_32();
+  uint32_t packet_id = context.random.generate_u32();
   std::unique_ptr<const Packet> packet;
   {
     std::lock_guard<std::mutex> guard(mutex_containers);
     while (packet_id == PACKET_ID_NONE || containers.find(packet_id) != containers.end()) {
-      packet_id = Utils::get_rnd_32();
+      packet_id = context.random.generate_u32();
     }
 
     std::tuple<CommandID::Type, PacketMode::Type> t = command->get_define();
@@ -181,11 +181,11 @@ void ModuleBase::send_packet(
 void ModuleBase::send_packet(
     const NodeID& dst_nid, PacketMode::Type mode, CommandID::Type command_id,
     std::shared_ptr<const std::string> content) {
-  uint32_t packet_id = Utils::get_rnd_32();
+  uint32_t packet_id = context.random.generate_u32();
   {
     std::lock_guard<std::mutex> guard(mutex_containers);
     while (packet_id == PACKET_ID_NONE || containers.find(packet_id) != containers.end()) {
-      packet_id = Utils::get_rnd_32();
+      packet_id = context.random.generate_u32();
     }
   }
 

--- a/src/core/node_id.cpp
+++ b/src/core/node_id.cpp
@@ -28,6 +28,7 @@ extern "C" {
 #include "definition.hpp"
 #include "internal_exception.hpp"
 #include "node_id.hpp"
+#include "random.hpp"
 #include "utils.hpp"
 
 namespace colonio {
@@ -223,8 +224,8 @@ NodeID NodeID::make_hash_from_str(const std::string& str) {
  * Make a rundom node-id.
  * @return A node-id.
  */
-NodeID NodeID::make_random() {
-  return NodeID(Utils::get_rnd_64(), Utils::get_rnd_64());
+NodeID NodeID::make_random(Random& random) {
+  return NodeID(random.generate_u64(), random.generate_u64());
 }
 
 NodeID& NodeID::operator=(const NodeID& src) {

--- a/src/core/node_id.hpp
+++ b/src/core/node_id.hpp
@@ -25,6 +25,7 @@ namespace colonio {
 namespace core {
 class NodeID;
 }  // namespace core
+class Random;
 
 /**
  * NodeID is the ID it assigned for each node process run in any devices.
@@ -63,7 +64,7 @@ class NodeID {
   static NodeID from_str(const std::string& str);
   static NodeID from_pb(const core::NodeID& pb);
   static NodeID make_hash_from_str(const std::string& str);
-  static NodeID make_random();
+  static NodeID make_random(Random& random);
 
   NodeID();
   NodeID(const NodeID& src);

--- a/src/core/random.cpp
+++ b/src/core/random.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2020 Yuji Ito <llamerada.jp@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "random.hpp"
+
+// Random value generator.
+#ifndef EMSCRIPTEN
+int generate_seed() {
+  std::random_device seed_gen;
+  int seed = seed_gen();
+  // avoid WSL2 issue https://github.com/microsoft/WSL/issues/5767
+  if (seed = 0xFFFFFFFF) {
+    seed = static_cast<int>(clock());
+  }
+  return seed;
+}
+#else
+extern "C" {
+extern double utils_get_random_seed();
+}
+
+int generate_seed() {
+  return INT_MAX * utils_get_random_seed();
+}
+#endif
+
+namespace colonio {
+
+Random::Random() : rnd32(generate_seed()), rnd64(generate_seed()) {
+}
+
+Random::~Random() {
+}
+
+uint32_t Random::generate_u32() {
+  return rnd32();
+}
+
+uint32_t Random::generate_u32(uint32_t min, uint32_t max) {
+  std::uniform_int_distribution<uint32_t> dist(min, max);
+  return dist(rnd32);
+}
+
+uint64_t Random::generate_u64() {
+  return rnd64();
+}
+
+double Random::generate_double(double min, double max) {
+  std::uniform_real_distribution<double> dist(min, max);
+  return dist(rnd32);
+}
+}  // namespace colonio

--- a/src/core/random.hpp
+++ b/src/core/random.hpp
@@ -15,25 +15,27 @@
  */
 #pragma once
 
-#include "node_id.hpp"
-#include "random.hpp"
+#include <cstdint>
+#include <random>
 
 namespace colonio {
-class Logger;
-class Scheduler;
 
-class Context {
+class Random {
  public:
-  Logger& logger;
-  Random& random;
-  Scheduler& scheduler;
-  const NodeID local_nid;
+  Random();
+  virtual ~Random();
 
-  Context(Logger& logger_, Random& random_, Scheduler& scheduler_);
-  virtual ~Context();
+  uint32_t generate_u32();
+  uint32_t generate_u32(uint32_t min, uint32_t max);
+  uint64_t generate_u64();
+  double generate_double(double min, double max);
 
  private:
-  Context(const Context&);
-  void operator=(const Context&);
+  std::mt19937 rnd32;
+  std::mt19937_64 rnd64;
+
+  Random(const Random&);
+  void operator=(const Random&);
 };
+
 }  // namespace colonio

--- a/src/core/routing.cpp
+++ b/src/core/routing.cpp
@@ -316,7 +316,7 @@ void Routing::update_seed_connection() {
       }
     }
     if (count == 0) {
-      if (Utils::get_rnd_32() % CONFIG_SEED_CONNECT_RATE == 0) {
+      if (context.random.generate_u32() % CONFIG_SEED_CONNECT_RATE == 0) {
         delegate.routing_do_connect_seed(*this);
       }
       return;

--- a/src/core/routing_1d.cpp
+++ b/src/core/routing_1d.cpp
@@ -427,7 +427,7 @@ void Routing1D::update_required_nodes() {
     }
 
     if (need_connect && r_nids.size() > 0) {
-      int idx           = Utils::get_rnd_32() % r_nids.size();
+      int idx           = context.random.generate_u32() % r_nids.size();
       const NodeID& nid = r_nids[idx];
       required_nodes.insert(nid);
     }

--- a/src/core/routing_2d.hpp
+++ b/src/core/routing_2d.hpp
@@ -37,6 +37,11 @@ class Routing2D : public RoutingAlgorithm {
   const NodeID& get_relay_nid(const Coordinate& position);
 
  private:
+  struct RoutingInfo {
+    int64_t timestamp;
+    Coordinate position;
+    std::map<NodeID, Coordinate> nodes;
+  };
   Context& context;
   RoutingAlgorithm2DDelegate& delegate;
   const CoordSystem& coord_system;
@@ -45,6 +50,7 @@ class Routing2D : public RoutingAlgorithm {
   std::set<NodeID> nearby_nids;
   std::map<NodeID, Coordinate> nearby_nodes;
   std::map<NodeID, Coordinate> known_nodes;
+  std::map<NodeID, RoutingInfo> routing_info_cache;
 
   void check_duplicate_point(const std::vector<NodeID>& nids, std::vector<double>* x_vec, std::vector<double>* y_vec);
   void shift_duplicate_point(const NodeID& nid, double* x, double* y);

--- a/src/core/utils.hpp
+++ b/src/core/utils.hpp
@@ -110,10 +110,6 @@ std::string dump_binary(const std::string& bin);
 std::string dump_packet(const Packet& packet, unsigned int indent = 2);
 int64_t get_current_msec();
 std::string get_current_thread_id();
-uint32_t get_rnd_32();
-uint32_t get_rnd_32(uint32_t min, uint32_t max);
-uint64_t get_rnd_64();
-double get_rnd_double(double min, double max);
 
 template<typename T>
 const T* get_json_value(const picojson::object& parent, const std::string& key) {

--- a/src/map_paxos/map_paxos_module.cpp
+++ b/src/map_paxos/map_paxos_module.cpp
@@ -131,7 +131,7 @@ void MapPaxosModule::CommandGet::postprocess() {
       int64_t interval =
           info->time_send +
           random.generate_u32(info->parent.CONF_RETRY_INTERVAL_MIN, info->parent.CONF_RETRY_INTERVAL_MAX) -
-                         Utils::get_current_msec();
+          Utils::get_current_msec();
       info->parent.send_packet_get(
           std::move(info->key), info->count_retry + 1, interval, info->cb_on_success, info->cb_on_failure);
     }
@@ -206,7 +206,7 @@ MapPaxosModule::CommandPrepare::CommandPrepare(std::shared_ptr<MapPaxosModule::C
 
 void MapPaxosModule::CommandPrepare::on_error(const std::string& message) {
   logD(info->parent.context, "error on packet of 'prepare'").map("message", message);
-  info->replys.push_back(Reply(NodeID::NONE, 0, 0, false));
+  info->replies.push_back(Reply(NodeID::NONE, 0, 0, false));
 
   postprocess();
 }
@@ -215,7 +215,7 @@ void MapPaxosModule::CommandPrepare::on_failure(std::unique_ptr<const Packet> pa
   MapPaxosProtocol::PrepareFailure content;
   packet->parse_content(&content);
 
-  info->replys.push_back(Reply(packet->src_nid, content.n(), 0, false));
+  info->replies.push_back(Reply(packet->src_nid, content.n(), 0, false));
 
   postprocess();
 }
@@ -224,7 +224,7 @@ void MapPaxosModule::CommandPrepare::on_success(std::unique_ptr<const Packet> pa
   MapPaxosProtocol::PrepareSuccess content;
   packet->parse_content(&content);
 
-  info->replys.push_back(Reply(packet->src_nid, content.n(), content.i(), true));
+  info->replies.push_back(Reply(packet->src_nid, content.n(), content.i(), true));
 
   postprocess();
 }
@@ -254,9 +254,9 @@ void MapPaxosModule::CommandPrepare::postprocess() {
   }
   ProposerInfo& proposer = proposer_it->second;
 
-  for (const auto& src : info->replys) {
+  for (const auto& src : info->replies) {
     if (src.is_success) {
-      for (auto& target : info->replys) {
+      for (auto& target : info->replies) {
         if (src.src_nid == target.src_nid && src.n == target.n) {
           target.is_success = true;
         }
@@ -265,7 +265,7 @@ void MapPaxosModule::CommandPrepare::postprocess() {
   }
   int count_ok = 0;
   int count_ng = 0;
-  for (const auto& it : info->replys) {
+  for (const auto& it : info->replies) {
     if (it.is_success) {
       count_ok++;
       if (it.i > info->i_max) {
@@ -329,7 +329,7 @@ MapPaxosModule::CommandAccept::CommandAccept(std::shared_ptr<MapPaxosModule::Com
 
 void MapPaxosModule::CommandAccept::on_error(const std::string& message) {
   logD(info->parent.context, "error on packet of 'accept'").map("message", message);
-  info->replys.push_back(Reply(NodeID::NONE, 0, 0, false));
+  info->replies.push_back(Reply(NodeID::NONE, 0, 0, false));
 
   postprocess();
 }
@@ -338,7 +338,7 @@ void MapPaxosModule::CommandAccept::on_failure(std::unique_ptr<const Packet> pac
   MapPaxosProtocol::AcceptFailure content;
   packet->parse_content(&content);
 
-  info->replys.push_back(Reply(packet->src_nid, content.n(), content.i(), false));
+  info->replies.push_back(Reply(packet->src_nid, content.n(), content.i(), false));
 
   postprocess();
 }
@@ -347,7 +347,7 @@ void MapPaxosModule::CommandAccept::on_success(std::unique_ptr<const Packet> pac
   MapPaxosProtocol::AcceptSuccess content;
   packet->parse_content(&content);
 
-  info->replys.push_back(Reply(packet->src_nid, content.n(), content.i(), true));
+  info->replies.push_back(Reply(packet->src_nid, content.n(), content.i(), true));
 
   postprocess();
 }
@@ -377,9 +377,9 @@ void MapPaxosModule::CommandAccept::postprocess() {
   }
   ProposerInfo& proposer = proposer_it->second;
 
-  for (const auto& src : info->replys) {
+  for (const auto& src : info->replies) {
     if (src.is_success) {
-      for (auto& target : info->replys) {
+      for (auto& target : info->replies) {
         if (src.src_nid == target.src_nid && src.n == target.n && src.i == target.i) {
           target.is_success = true;
         }
@@ -388,7 +388,7 @@ void MapPaxosModule::CommandAccept::postprocess() {
   }
   int count_ok = 0;
   int count_ng = 0;
-  for (const auto& it : info->replys) {
+  for (const auto& it : info->replies) {
     if (it.is_success) {
       count_ok++;
       if (it.i > info->i_max) {
@@ -705,7 +705,7 @@ void MapPaxosModule::recv_packet_get(std::unique_ptr<const Packet> packet) {
 
   auto acceptor_it = acceptor_infos.find(key);
   if (acceptor_it == acceptor_infos.end() || acceptor_it->second.na == 0) {
-    // TODO(llamerada.jp@gmail.com) Search data from another accetpors.
+    // TODO(llamerada.jp@gmail.com) Search data from another acceptors.
     send_failure(*packet, std::shared_ptr<std::string>());
 
   } else {

--- a/src/map_paxos/map_paxos_module.hpp
+++ b/src/map_paxos/map_paxos_module.hpp
@@ -26,6 +26,7 @@ const &
 #include "core/module_1d.hpp"
 
 namespace colonio {
+class Random;
 typedef uint32_t PAXOS_N;
 
 class MapPaxosModule : public Module1D {
@@ -91,9 +92,10 @@ class MapPaxosModule : public Module1D {
       Info(MapPaxosModule& parent_, std::unique_ptr<Value> key_, int count_retry_);
     };
 
+    Random& random;
     std::shared_ptr<Info> info;
 
-    CommandGet(std::shared_ptr<Info> info_);
+    CommandGet(Random& random_, std::shared_ptr<Info> info_);
 
     void on_error(const std::string& message) override;
     void on_failure(std::unique_ptr<const Packet> packet) override;

--- a/src/map_paxos/map_paxos_module.hpp
+++ b/src/map_paxos/map_paxos_module.hpp
@@ -149,7 +149,7 @@ class MapPaxosModule : public Module1D {
       PAXOS_N i_max;
       uint32_t opt;
       MapPaxosModule& parent;
-      std::vector<Reply> replys;
+      std::vector<Reply> replies;
       bool is_finished;
       Info(
           MapPaxosModule& parent_, std::unique_ptr<const Packet> packet_reply_, std::unique_ptr<Value> key_,
@@ -187,7 +187,7 @@ class MapPaxosModule : public Module1D {
       PAXOS_N i_max;
       uint32_t opt;
       MapPaxosModule& parent;
-      std::vector<Reply> replys;
+      std::vector<Reply> replies;
       bool is_finished;
 
       Info(

--- a/src/pubsub_2d/pubsub_2d_module.cpp
+++ b/src/pubsub_2d/pubsub_2d_module.cpp
@@ -158,9 +158,9 @@ void Pubsub2DModule::CommandPass::on_success(std::unique_ptr<const Packet> packe
 }
 
 uint64_t Pubsub2DModule::assign_uid() {
-  uint64_t uid = Utils::get_rnd_64();
+  uint64_t uid = context.random.generate_u64();
   while (cache.find(uid) != cache.end()) {
-    uid = Utils::get_rnd_64();
+    uid = context.random.generate_u64();
   }
   return uid;
 }

--- a/test/core/coord_system_plane_test.cpp
+++ b/test/core/coord_system_plane_test.cpp
@@ -18,6 +18,8 @@
 
 #include <gtest/gtest.h>
 
+#include "core/random.hpp"
+
 using namespace colonio;
 
 TEST(CoordSystemPlaneTest, test) {
@@ -28,7 +30,8 @@ TEST(CoordSystemPlaneTest, test) {
     std::cerr << err << std::endl;
     FAIL();
   }
-  CoordSystemPlane plane(v.get<picojson::object>());
+  Random random;
+  CoordSystemPlane plane(random, v.get<picojson::object>());
 
   EXPECT_FLOAT_EQ(plane.MIN_X, -1.0);
   EXPECT_FLOAT_EQ(plane.MAX_X, 1.0);

--- a/test/core/node_id_test.cpp
+++ b/test/core/node_id_test.cpp
@@ -20,6 +20,7 @@
 
 #include "core/core.pb.h"
 #include "core/internal_exception.hpp"
+#include "core/random.hpp"
 
 using namespace colonio;
 
@@ -126,9 +127,11 @@ TEST(NodeIDTest, make_hash_from_str) {
 }
 
 TEST(NodeIDTest, make_random) {
-  NodeID test00 = NodeID::make_random();
-  NodeID test01 = NodeID::make_random();
-  NodeID test02 = NodeID::make_random();
+  Random random;
+
+  NodeID test00 = NodeID::make_random(random);
+  NodeID test01 = NodeID::make_random(random);
+  NodeID test02 = NodeID::make_random(random);
 
   EXPECT_NE(test00, test01);
   EXPECT_NE(test01, test02);
@@ -136,8 +139,10 @@ TEST(NodeIDTest, make_random) {
 }
 
 TEST(NodeIDTest, eq) {
+  Random random;
+
   NodeID test00;
-  NodeID test01 = NodeID::make_random();
+  NodeID test01 = NodeID::make_random(random);
 
   test00 = test01;
   EXPECT_NE(test00, NodeID::NONE);
@@ -146,8 +151,10 @@ TEST(NodeIDTest, eq) {
 }
 
 TEST(NodeIDTest, pluseq) {
-  NodeID test0 = NodeID::make_random();
-  NodeID test1 = NodeID::make_random();
+  Random random;
+
+  NodeID test0 = NodeID::make_random(random);
+  NodeID test1 = NodeID::make_random(random);
   NodeID test2 = test0 + test1;
   NodeID test3 = test0;
   test3 += test1;

--- a/test/test_utils/test_seed.hpp
+++ b/test/test_utils/test_seed.hpp
@@ -25,7 +25,6 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
-#include <mutex>
 #include <thread>
 
 class TestSeed {


### PR DESCRIPTION
- make std::random for each context to avoid block by a mutex.
- remove catching std::exception to show stack trace on debugging.
- stabilize routing 2d algorithm.
- fix crash bugs caused by out of range from map object.